### PR TITLE
Guess fixes

### DIFF
--- a/guess/sshfsroot/config.mk
+++ b/guess/sshfsroot/config.mk
@@ -1,7 +1,11 @@
+ifeq "$(call if-recently-activated-feature,sshfsroot)" "sshfsroot"
+GUESS_MODULES += sshfsroot
+endif
+
 ifeq "$(call if-active-feature,sshfsroot)/$(call if-module-guessable,net)" "sshfsroot/net"
 
 ifeq "$(GUESS_NET_IFACE)" ''
-GUESS_MODULE += net
+GUESS_MODULES += net
 endif
 
 ifeq "$(GUESS_NET_IFACE)" ''

--- a/mk/functions.mk.in
+++ b/mk/functions.mk.in
@@ -122,6 +122,9 @@ require = \
 # $(call if-active-feature,<name> [<name1> ...])
 if-active-feature = $(if $(1),$(filter $(1),$(get-all-active-features)))
 
+# $(call if-recently-activated-feature,<name> [<name1> ...])
+if-recently-activated-feature = $(if $(1),$(filter $(1),$(RECENTLY_ACTIVATED_FEATURES)))
+
 # $(call if-module-guessable,<name> [<name1> ...])
 if-module-guessable = $(if $(1),$(filter $(1),\
 					$(if $(findstring all,$(AUTODETECT)), \

--- a/mk/make-initrd.mk.in
+++ b/mk/make-initrd.mk.in
@@ -41,6 +41,8 @@ endif
 
 -include $(GUESSDIR)/guessed.mk
 
+RECENTLY_ACTIVATED_FEATURES := $(filter-out $(ALL_ACTIVE_FEATURES),$(get-all-active-features))
+
 GUESS_CONFIG_MODULES = \
 		$(foreach mod1, \
 			$(if $(findstring all,$(AUTODETECT)), \


### PR DESCRIPTION
1. Add RECENTLY_ACTIVATED_FEATURE variable to monitor recently added features
2. Force rerun rules.mk if sshfsroot feature is recently added


guess/sshfsroor/rules.mk may be called when sshfsroot feature is not actualy active. We need to force restart this module when sshfsroot feature is activated.