### PR TITLE
make-initrd.mk: Guess-config calls guess goal using make.

### DIFF
--- a/mk/make-initrd.mk.in
+++ b/mk/make-initrd.mk.in
@@ -216,7 +216,7 @@ INITRD_CONFIG = /dev/null
 include @projectdir@/mk/config.mk
 $(call show-feature-dependency,$(FEATURE_NAMES))
 
-.PHONY: show-eature-info
+.PHONY: show-feature-info
 
 show-feature-info:
 	@:

--- a/mk/make-initrd.mk.in
+++ b/mk/make-initrd.mk.in
@@ -32,7 +32,7 @@ STARTUP_TIME   = $(shell date +'%s')
 WORKDIR_SUFFIX = $(basename $(notdir $(INITRD_CONFIG)))
 endif
 
-ifneq "$(filter guess guess-config guess-modules,$(MAKECMDGOALS))" ''
+ifneq "$(filter guess guess-modules,$(MAKECMDGOALS))" ''
 AUTODETECT ?= all
 
 ifeq "$(MAKECMDGOALS)" 'guess-modules'
@@ -186,7 +186,8 @@ process-config: $(INITRD_CONFIG)
 	@$(MAKE) $(MFLAGS) -f @projectdir@/mk/make-initrd.mk guess
 	@$(MAKE) $(MFLAGS) -f @projectdir@/mk/make-initrd.mk genimage
 
-guess-config: check-for-root guess
+guess-config: check-for-root
+	@$(MAKE) $(MFLAGS) -f @projectdir@/mk/make-initrd.mk guess
 	@cat $(GUESSDIR)/guessed.mk >&4
 	$Qrm -rf -- "$(GUESSDIR)"
 	$Qrmdir -- "$(WORKDIR)"

--- a/utils/make-initrd/make-initrd.in
+++ b/utils/make-initrd/make-initrd.in
@@ -34,7 +34,7 @@ show_help() {
 
 	Usage: make-initrd [<option>]
 	   or: make-initrd guess-modules [<device>|<directory>]
-	   or: make-initrd guess-config
+	   or: make-initrd guess-config [-c <config>]
 	   or: make-initrd bug-report
 
 	make-initrd is a new, uevent-driven initramfs
@@ -50,6 +50,8 @@ show_help() {
 	guess-config
 	               guesses the current configuration
 	               and generates the config file;
+	               guesses extention of the config file
+	               if -c option passed;
 
 	guess-modules [<device>|<directory>]
 	               shows kernel module needed to mount
@@ -146,7 +148,11 @@ while :; do
 done
 
 case "${1-}" in
-	guess-config|bug-report)
+	bug-report)
+		;;
+	guess-config)
+		[ -z "$config" ] ||
+			export INITRD_CONFIG="$config"
 		;;
 	guess-modules)
 		[ "$#" -eq 2 ] ||


### PR DESCRIPTION
This allows to get complemented guessed.mk for some config:
make-initrd guess-config INITRD_CONFIG=/path/to/config

Signed-off-by: Михалицын Петр <pmikhalicin@rutoken.ru>