### PR TITLE
guess root: Replace MOUNTPOINTS to GUESS_MOUNTPOINTS inside guess module

### DIFF
--- a/guess/root/README.md
+++ b/guess/root/README.md
@@ -5,5 +5,5 @@ filesystem itself (if they are not added in the kernel).
 
 # Parameters
 
-- **MOUNTPOINTS** -- this is a list of mountpoints. The kernel modules will be
+- **GUESS_MOUNTPOINTS** -- this is a list of mountpoints. The kernel modules will be
   found for devices mounted at these mountpoints.

--- a/guess/root/action
+++ b/guess/root/action
@@ -177,7 +177,7 @@ system_findmnt()
 fi	# MAKE_INITRD_BUG_REPORT
 
 pass=' '
-for dir in ${MOUNTPOINTS-}; do
+for dir in ${GUESS_MOUNTPOINTS-}; do
 	[ -n "${pass##* $dir *}" ] ||
 		continue
 
@@ -201,3 +201,5 @@ for dir in ${MOUNTPOINTS-}; do
 
 	pass="$pass$dir "
 done
+
+guess_variable MOUNTPOINTS "${pass}"

--- a/guess/root/action
+++ b/guess/root/action
@@ -176,8 +176,11 @@ system_findmnt()
 
 fi	# MAKE_INITRD_BUG_REPORT
 
+[ "${MOUNTPOINTS-}" == "/" ] ||
+	echo "Warning: Using MOUNTPOINTS variable for guess module is deprecated. Use GUESS_MOUNTPOINTS instead" 1>&2
+
 pass=' '
-for dir in ${GUESS_MOUNTPOINTS-}; do
+for dir in ${MOUNTPOINTS-} ${GUESS_MOUNTPOINTS-}; do
 	[ -n "${pass##* $dir *}" ] ||
 		continue
 

--- a/guess/root/config.mk
+++ b/guess/root/config.mk
@@ -3,4 +3,4 @@
 #   comment="x-initrd-mount"
 #   x-initrd-mount
 #
-MOUNTPOINTS += $(shell LIBMOUNT_FSTAB=$(FSTAB) findmnt -s -O x-initrd-mount -no TARGET 2>/dev/null ||:)
+GUESS_MOUNTPOINTS += / $(shell LIBMOUNT_FSTAB=$(FSTAB) findmnt -s -O x-initrd-mount -no TARGET 2>/dev/null ||:)

--- a/utils/make-initrd/make-initrd.in
+++ b/utils/make-initrd/make-initrd.in
@@ -153,18 +153,18 @@ case "${1-}" in
 			fatal "More arguments required"
 
 		INITRD_CONFIG=/dev/null
-		MOUNTPOINTS=
+		GUESS_MOUNTPOINTS=
 		DEVICES=
 
 		if [ -d "$2" ]; then
-			MOUNTPOINTS="$2"
+			GUESS_MOUNTPOINTS="$2"
 		elif [ -b "$2" ]; then
 			DEVICES="$2"
 		else
 			fatal "$2: argument type unsupported"
 		fi
 
-		export MOUNTPOINTS DEVICES INITRD_CONFIG
+		export GUESS_MOUNTPOINTS DEVICES INITRD_CONFIG
 
 		set -- "$1"
 		;;


### PR DESCRIPTION
Usage of MOUNTPOINTS variable is mixed with guess module and some
features. Now MOUNTPOINTS variable contains accurate list of mountpoint,
which will be mounted inside initrd. GUESS_MOUNTPOINTS is used inside
guess module to find this accurate list.

Signed-off-by: Petr Mikhalicin <pmikhalicin@rutoken.ru>