### PR TITLE
Add feature sbc for single board computers support

### DIFF
--- a/features/modules-sbc/README.md
+++ b/features/modules-sbc/README.md
@@ -1,0 +1,7 @@
+# Feature: sbc
+
+Feature adds modules required for bootloading on single-board computers.
+make-initrd on single board computers does not add required modules to
+initramfs. These are various voltage regulators, i2c interfaces, etc.
+Another reason is the ability to transfer the system from one board to
+another, as well as from one interface of one board to another.

--- a/features/modules-sbc/config.mk
+++ b/features/modules-sbc/config.mk
@@ -1,0 +1,1 @@
+$(call feature-requires,depmod-image)

--- a/features/modules-sbc/rules.mk
+++ b/features/modules-sbc/rules.mk
@@ -1,0 +1,17 @@
+MODULES_TRY_ADD += \
+	drivers/bus         \
+	drivers/dma         \
+	drivers/i2c         \
+	drivers/mfd         \
+	drivers/mmc         \
+	drivers/nvmem       \
+	drivers/phy         \
+	drivers/regulator   \
+	drivers/reset       \
+	drivers/soc         \
+	drivers/usb/host    \
+	drivers/usb/storage \
+	drivers/usb/dwc2    \
+	drivers/usb/dwc3    \
+	drivers/usb/musb    \
+	drivers/usb/phy


### PR DESCRIPTION
For not all single board computers, make-initrd can build an initrd
to boot successfully.