### PR TITLE
mkinitrd-make-initrd: Fixed misprint, make-initrd can be found now.

### DIFF
--- a/utils/mkinitrd-make-initrd/mkinitrd-make-initrd.in
+++ b/utils/mkinitrd-make-initrd/mkinitrd-make-initrd.in
@@ -86,6 +86,6 @@ if [ -f "$IMAGEFILE" ] && [ -z "$FORCE" ]; then
 fi
 
 cwd="$(readlink -f "$0")"
-cwd="${cwd%/}"
+cwd="${cwd%/*}"
 
 exec "$cwd"/make-initrd -k "$2"


### PR DESCRIPTION
Signed-off-by: Andrei Iakunin <iakuninaa@altlinux.org>

Fixed: 
"/usr/sbin/mkinitrd-make-initrd: line 91: /usr/sbin/mkinitrd-make-initrd/make-initrd: Not a directory"
bug in mkinitrd-make-initrd