### PR TITLE
fix microcode early update %p

### DIFF
--- a/features/ucode/bin/add-ucode
+++ b/features/ucode/bin/add-ucode
@@ -107,9 +107,9 @@ if [ -d "$workdir/ucode" ]; then
 
 	# shellcheck disable=SC2185
 	find -O2 . -mindepth 1 \
-		   \( -type f -a -printf 'file %p %p %#m 0 0\n'  \) \
-		-o \( -type l -a -printf 'slink %p %l %#m 0 0\n' \) \
-		-o \( -type d -a -printf 'dir %p %#m 0 0\n'      \) |
+		   \( -type f -a -printf 'file %P %P %#m 0 0\n'  \) \
+		-o \( -type l -a -printf 'slink %P %l %#m 0 0\n' \) \
+		-o \( -type d -a -printf 'dir %P %#m 0 0\n'      \) |
 		sort |
 		gen_init_cpio -t 0 - > "$workdir"/ucode.cpio
 


### PR DESCRIPTION
iucode_tool creates ucode.cpio with path like "kernel/x86/microcode/GenuineIntel.bin"

find -printf "%p" put a prefix into this path like "./kernel/x86/microcode/GenuineIntel.bin"

So the microcode is not loaded and I get errors like "TSC_DEADLINE disabled due to Errata" in dmesg

using "%P" fixes this problem.

Signed-off-by: hundertzwei <46927478+hundertzwei@users.noreply.github.com>