### PR TITLE
kickstart: use non-interactively mode for e2fsck

### DIFF
--- a/features/kickstart/data/bin/kickstart-sh-storage
+++ b/features/kickstart/data/bin/kickstart-sh-storage
@@ -575,7 +575,7 @@ ks_growfs()
 
        case "$fs" in
                ext*)
-                       e2fsck -f "$1" && resize2fs "$1" ||
+                       e2fsck -yf "$1" && resize2fs "$1" ||
                                ret=1
                        ;;
                xfs)


### PR DESCRIPTION
When there is no RTC or battery at RTC e2fsck the superblock creation time is in the future and user confirmation is required. This is not what is needed. The user does not have to confirm anything.