### PR TITLE
Generate ld.so.conf config for initrd

### DIFF
--- a/tools/create-initrd
+++ b/tools/create-initrd
@@ -282,6 +282,8 @@ printf '%s\n' "${!DIRS[@]}"       |xargs -r put-tree .
 printf '%s\n' "${!FILES[@]}"      |xargs -r put-file .
 printf '%s\n' "${!LOCALFILES[@]}" |xargs -r put-file -r "$LOCALBUILDDIR" .
 
+gen-ld-so-conf . > etc/ld.so.conf
+
 ln_if_missing "$UDEVD"   ./sbin/udevd
 ln_if_missing "$UDEVADM" ./sbin/udevadm
 

--- a/tools/gen-ld-so-conf
+++ b/tools/gen-ld-so-conf
@@ -1,0 +1,43 @@
+#!/bin/bash -eu
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+root="$1"; shift
+[ -d "$root" ] || exit 1
+[ -s /etc/ld.so.conf ] || exit 0
+
+parse_glob() {
+	local g="$1"; shift
+	local f
+
+	for f in $g; do
+		if [ -s "$f" ]; then
+			parse_config "$f"
+		fi
+	done
+}
+
+parse_config() {
+	local f="$1"; shift
+	local dname="${f%/*}"
+	local w rest
+
+	while read -r w rest; do {
+		case "$w" in
+			'#'*|'') ;;
+			include)
+				if [ -z "${rest##/*}" ]; then
+					parse_glob "$rest"
+				else
+					parse_glob "$dname/$rest"
+				fi
+				;;
+			*)
+				if [ -z "$rest" ] && [ -d "$root$w" ]; then
+					printf '%s\n' "$w"
+				fi
+				;;
+		esac
+	} </dev/null; done < "$f"
+}
+
+parse_config /etc/ld.so.conf


### PR DESCRIPTION
This change is important for generating initrd images, for example, on Gentoo systems.  On Gentoo, libgcc_s.so.1 is located under /usr/lib/gcc, and, unlike most other libraries, is found by the dynamic linker due to the ld.so.conf configuration.