### PR TITLE
utils/initrd-put/initrd-put.c: Remove use of rawmemchr(3)

### DIFF
--- a/utils/initrd-put/initrd-put.c
+++ b/utils/initrd-put/initrd-put.c
@@ -216,7 +216,7 @@ void enqueue_canonicalized_path(const char *name, bool add_recursively)
 	if (!IS_ABSOLUTE_FILE_NAME(name)) {
 		if (getcwd(rname, sizeof(rname)) == NULL)
 			err(EXIT_FAILURE, "unable to get current directory");
-		dest = rawmemchr(rname, '\0');
+		dest = rname + strlen(rname);
 	} else {
 		dest = rname;
 		*dest++ = '/';


### PR DESCRIPTION
rawmemchr(3) is a GNU extension, so it's not portable, also it is deprecated.