### PR TITLE
Add initial musl libc support

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -134,7 +134,7 @@ CFLAGS = @CFLAGS@ \
 	-Wno-pointer-arith \
 	-Werror=shadow -Werror=missing-prototypes -Werror=implicit-function-declaration
 
-CPPFLAGS += @CPPFLAGS@ @DEFS@ -I$(CURDIR)
+CPPFLAGS += @CPPFLAGS@ @DEFS@ -I$(CURDIR) -I$(CURDIR)/include
 
 UDEVD		= @UDEVD@
 UDEVADM		= @UDEVADM@

--- a/Makefile.in
+++ b/Makefile.in
@@ -57,6 +57,8 @@ dest_data_sbindir := $(dest_runtimedir)/sbin
 dest_data_libdir  := $(dest_runtimedir)/$(libcdir)
 dest_featuredir   := $(dest_execdir)/$(FEATURESDIR)
 
+fts_LIBS := @fts_LIBS@
+
 HAVE_GZIP        := @HAVE_GZIP@
 HAVE_GZIP_LIBS   := @HAVE_GZIP_LIBS@
 HAVE_GZIP_CFLAGS := @HAVE_GZIP_CFLAGS@

--- a/configure.ac
+++ b/configure.ac
@@ -56,6 +56,16 @@ AC_CHECK_FUNCS([ \
 		strpbrk strrchr strstr strtol strtoul strtoull uname \
 		twalk_r tdestroy updwtmp])
 
+saved_LIBS="$LIBS"
+AC_SEARCH_LIBS([fts_close], [fts])
+LIBS="$saved_LIBS"
+case "$ac_cv_search_fts_close" in
+	no) AC_MSG_FAILURE([failed to find fts_close]) ;;
+	-l*) fts_LIBS="$ac_cv_search_fts_close" ;;
+	*) fts_LIBS= ;;
+esac
+AC_SUBST([fts_LIBS])
+
 AC_MSG_CHECKING([if in-tree build is required])
 AC_ARG_ENABLE(local-build,
 	[AS_HELP_STRING(--enable-local-build,

--- a/features/sshfsroot/src/ask-pass/ask-pass.c
+++ b/features/sshfsroot/src/ask-pass/ask-pass.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "config.h"
+
 #include <stdio.h>
 #include <termios.h>
 #include <unistd.h>

--- a/include/temp_failure_retry.h
+++ b/include/temp_failure_retry.h
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 1991-2025 Free Software Foundation, Inc.
+
+#ifndef _TEMP_FAILURE_RETRY_H
+# define _TEMP_FAILURE_RETRY_H	1
+
+# include <unistd.h>
+
+# ifndef TEMP_FAILURE_RETRY
+/* This implementation of TEMP_FAILURE_RETRY is taken from the glibc code. */
+#  define TEMP_FAILURE_RETRY(expression)				\
+   (__extension__							\
+     ({ long int __result;						\
+        do __result = (long int) (expression);				\
+        while (__result == -1L && errno == EINTR);			\
+        __result; }))
+
+# endif
+#endif

--- a/runtime/src/chrooted/chrooted.c
+++ b/runtime/src/chrooted/chrooted.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "config.h"
+
 #include <sys/stat.h>
 #include <unistd.h>
 #include <stdlib.h>

--- a/runtime/src/environ/environ.c
+++ b/runtime/src/environ/environ.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "config.h"
+
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/runtime/src/halt/halt.c
+++ b/runtime/src/halt/halt.c
@@ -31,6 +31,8 @@
  *		Copyright (C) 1991-2004 Miquel van Smoorenburg.
  */
 
+#include "config.h"
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/param.h>

--- a/runtime/src/halt/hddown.c
+++ b/runtime/src/halt/hddown.c
@@ -7,6 +7,8 @@
  */
 const char *v_hddown = "@(#)hddown.c  1.02  22-Apr-2003  miquels@cistron.nl";
 
+#include "config.h"
+
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif

--- a/runtime/src/halt/ifdown.c
+++ b/runtime/src/halt/ifdown.c
@@ -7,6 +7,8 @@
  */
 const char *v_ifdown = "@(#)ifdown.c  1.11  02-Jun-1998  miquels@cistron.nl";
 
+#include "config.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/runtime/src/libinitramfs/console.c
+++ b/runtime/src/libinitramfs/console.c
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "config.h"
+
 #include <linux/kd.h>
 #include <sys/ioctl.h>
 

--- a/runtime/src/libinitramfs/logging.c
+++ b/runtime/src/libinitramfs/logging.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "config.h"
+
 #include <sys/uio.h>
 
 #include <stdio.h>

--- a/runtime/src/libinitramfs/logging.c
+++ b/runtime/src/libinitramfs/logging.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 #include <time.h>
 
+#include "temp_failure_retry.h"
 #include "rd/logging.h"
 
 int log_priority = LOG_INFO;

--- a/runtime/src/libinitramfs/memory.c
+++ b/runtime/src/libinitramfs/memory.c
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "config.h"
+
 #include <string.h>
 #include <stdlib.h>
 #include <stdarg.h>

--- a/runtime/src/nfsmount/dummypmap.c
+++ b/runtime/src/nfsmount/dummypmap.c
@@ -6,6 +6,8 @@
  * using RPC over UDP.
  */
 
+#include "config.h"
+
 #include <sys/types.h>
 #include <netinet/in.h>
 #include <stdio.h>

--- a/runtime/src/nfsmount/main.c
+++ b/runtime/src/nfsmount/main.c
@@ -1,3 +1,5 @@
+#include "config.h"
+
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/time.h>

--- a/runtime/src/nfsmount/mount.c
+++ b/runtime/src/nfsmount/mount.c
@@ -305,8 +305,8 @@ int nfs_mount(const char *pathname, const char *hostname,
 		goto bail;
 	}
 
-	if (bindresvport(sock, 0) == -1) {
-		perror("bindresvport");
+	if (bindanyprivport(sock) == -1) {
+		perror("bindanyprivport");
 		goto bail;
 	}
 

--- a/runtime/src/nfsmount/mount.c
+++ b/runtime/src/nfsmount/mount.c
@@ -1,3 +1,5 @@
+#include "config.h"
+
 #include <sys/mount.h>
 #include <sys/types.h>
 #include <sys/socket.h>

--- a/runtime/src/nfsmount/portmap.c
+++ b/runtime/src/nfsmount/portmap.c
@@ -1,3 +1,5 @@
+#include "config.h"
+
 #include <sys/types.h>
 #include <netinet/in.h>
 #include <asm/byteorder.h>	/* __constant_hton* */

--- a/runtime/src/nfsmount/sunrpc.c
+++ b/runtime/src/nfsmount/sunrpc.c
@@ -1,3 +1,5 @@
+#include "config.h"
+
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>

--- a/runtime/src/nfsmount/sunrpc.h
+++ b/runtime/src/nfsmount/sunrpc.h
@@ -99,6 +99,7 @@ struct client {
 
 #define CLI_RESVPORT	00000001
 
+int bindanyprivport(int sd);
 struct client *tcp_client(uint32_t server, uint16_t port, uint32_t flags);
 struct client *udp_client(uint32_t server, uint16_t port, uint32_t flags);
 void client_free(struct client *client);

--- a/runtime/src/resume/getarg.c
+++ b/runtime/src/resume/getarg.c
@@ -1,3 +1,5 @@
+#include "config.h"
+
 #include <string.h>
 #include "resume.h"
 

--- a/runtime/src/resume/name_to_dev.c
+++ b/runtime/src/resume/name_to_dev.c
@@ -1,3 +1,5 @@
+#include "config.h"
+
 #include <ctype.h>
 #include <fcntl.h>
 #include <sys/stat.h>

--- a/runtime/src/resume/resume.c
+++ b/runtime/src/resume/resume.c
@@ -2,6 +2,8 @@
  * Handle resume from suspend-to-disk
  */
 
+#include "config.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/runtime/src/resume/resumelib.c
+++ b/runtime/src/resume/resumelib.c
@@ -2,6 +2,8 @@
  * Handle resume from suspend-to-disk
  */
 
+#include "config.h"
+
 #include <unistd.h>
 #include <fcntl.h>
 #include <stdio.h>

--- a/runtime/src/runas/runas.c
+++ b/runtime/src/runas/runas.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "config.h"
+
 #include <stdio.h>
 #include <err.h>
 #include <string.h>

--- a/runtime/src/timestamp/timestamp.c
+++ b/runtime/src/timestamp/timestamp.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "config.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <time.h>

--- a/runtime/src/ueventd-mounts/ueventd-mounts.c
+++ b/runtime/src/ueventd-mounts/ueventd-mounts.c
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "config.h"
+
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>

--- a/runtime/src/ueventd/path.c
+++ b/runtime/src/ueventd/path.c
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "config.h"
+
 #include <stdlib.h>
 #include <dirent.h>
 #include <fcntl.h>

--- a/runtime/src/ueventd/path.c
+++ b/runtime/src/ueventd/path.c
@@ -7,6 +7,7 @@
 #include <fcntl.h>
 #include <errno.h>
 
+#include "temp_failure_retry.h"
 #include "rd/logging.h"
 #include "ueventd.h"
 

--- a/runtime/src/ueventd/process.c
+++ b/runtime/src/ueventd/process.c
@@ -12,6 +12,7 @@
 #include <unistd.h>
 #include <errno.h>
 
+#include "temp_failure_retry.h"
 #include "ueventd.h"
 
 pid_t waitpid_retry(pid_t pid, int *wstatus, int options)

--- a/runtime/src/ueventd/process.c
+++ b/runtime/src/ueventd/process.c
@@ -3,6 +3,9 @@
  * Copyright (C) 2022  Arseny Maslennikov <arseny@altlinux.org>
  * All rights reserved.
  */
+
+#include "config.h"
+
 #include <sys/types.h>
 #include <sys/wait.h>
 

--- a/runtime/src/ueventd/queue-processor.c
+++ b/runtime/src/ueventd/queue-processor.c
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "config.h"
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/wait.h>

--- a/runtime/src/ueventd/ueventd.c
+++ b/runtime/src/ueventd/ueventd.c
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "config.h"
+
 #include <sys/types.h>
 #include <sys/epoll.h>
 #include <sys/inotify.h>

--- a/system.h
+++ b/system.h
@@ -1,0 +1,1 @@
+#include "config.h"

--- a/tools/get-libc-dir
+++ b/tools/get-libc-dir
@@ -5,4 +5,4 @@ libc="$(
 	ldd "$BASH" |
 		sed -n -e 's|[[:space:]]*libc\.so.*[[:space:]]=>[[:space:]]\(/.*\)[[:space:]](0x.*$|\1|p'
 )"
-printf '%s\n' "${libc%/libc.so*}"
+printf '%s\n' "${libc%/*}"

--- a/utils/depinfo/kmod-depinfo.c
+++ b/utils/depinfo/kmod-depinfo.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #define _GNU_SOURCE
 
+#include "config.h"
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
@@ -18,8 +20,6 @@
 #include <libgen.h>
 #include <libkmod.h>
 #include <err.h>
-
-#include "config.h"
 
 enum alias_need {
 	ALIAS_OPTIONAL = 0,

--- a/utils/gen_init_cpio/gen_init_cpio.c
+++ b/utils/gen_init_cpio/gen_init_cpio.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
+
+#include "config.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>

--- a/utils/initrd-common.c
+++ b/utils/initrd-common.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "config.h"
+
 #include <stdlib.h>
 
 #include "initrd-common.h"

--- a/utils/initrd-cpio.c
+++ b/utils/initrd-cpio.c
@@ -1,3 +1,5 @@
+#include "config.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/utils/initrd-decompress-bzip2.c
+++ b/utils/initrd-decompress-bzip2.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "config.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/utils/initrd-decompress-gzip.c
+++ b/utils/initrd-decompress-gzip.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "config.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/utils/initrd-decompress-lzma.c
+++ b/utils/initrd-decompress-lzma.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "config.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/utils/initrd-decompress-zstd.c
+++ b/utils/initrd-decompress-zstd.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "config.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/utils/initrd-decompress.c
+++ b/utils/initrd-decompress.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "config.h"
+
 #include <stdio.h>
 #include <string.h>
 

--- a/utils/initrd-extract/initrd-extract.c
+++ b/utils/initrd-extract/initrd-extract.c
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #define _GNU_SOURCE
+
+#include "config.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -16,7 +19,6 @@
 #include "initrd-cpio.h"
 #include "initrd-decompress.h"
 #include "initrd-parse.h"
-#include "config.h"
 
 int opts = 0;
 

--- a/utils/initrd-ls/initrd-ls-format.c
+++ b/utils/initrd-ls/initrd-ls-format.c
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #define _GNU_SOURCE
+
+#include "config.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>

--- a/utils/initrd-ls/initrd-ls.c
+++ b/utils/initrd-ls/initrd-ls.c
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #define _GNU_SOURCE
+
+#include "config.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -18,7 +21,6 @@
 #include "initrd-decompress.h"
 #include "initrd-parse.h"
 #include "initrd-ls.h"
-#include "config.h"
 
 int opts = 0;
 

--- a/utils/initrd-parse.c
+++ b/utils/initrd-parse.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "config.h"
+
 #include <endian.h>
 #include <stdlib.h>
 #include <stdint.h>

--- a/utils/initrd-put/Makefile.mk
+++ b/utils/initrd-put/Makefile.mk
@@ -10,7 +10,7 @@ initrd_put_SRCS = \
 	$(utils_srcdir)/initrd-put/enqueue-shebang.c \
 	$(utils_srcdir)/initrd-put/initrd-put.c
 
-initrd_put_LIBS = $(HAVE_LIBELF_LIBS) $(HAVE_LIBJSON_C_LIBS)
+initrd_put_LIBS = $(fts_LIBS) $(HAVE_LIBELF_LIBS) $(HAVE_LIBJSON_C_LIBS)
 initrd_put_CFLAGS = $(HAVE_LIBELF_CFLAGS) $(HAVE_LIBJSON_C_CFLAGS) \
 		    -I$(utils_srcdir)/initrd-put \
 		    -DPACKAGE_VERSION=\"$(PACKAGE_VERSION)\"

--- a/utils/initrd-put/elf_dlopen.c
+++ b/utils/initrd-put/elf_dlopen.c
@@ -20,6 +20,7 @@
 #include <json-c/json.h>
 #include <json-c/json_visit.h>
 
+#include "temp_failure_retry.h"
 #include "memory.h"
 #include "elf_dlopen.h"
 

--- a/utils/initrd-put/elf_dlopen.c
+++ b/utils/initrd-put/elf_dlopen.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 #define _GNU_SOURCE
 
+#include "config.h"
+
 #include <sys/wait.h>
 #include <sys/prctl.h>
 
@@ -18,7 +20,6 @@
 #include <json-c/json.h>
 #include <json-c/json_visit.h>
 
-#include "config.h"
 #include "memory.h"
 #include "elf_dlopen.h"
 

--- a/utils/initrd-put/enqueue-library.c
+++ b/utils/initrd-put/enqueue-library.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #define _GNU_SOURCE
 
+#include "config.h"
+
 #include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/utils/initrd-put/enqueue-library.c
+++ b/utils/initrd-put/enqueue-library.c
@@ -22,6 +22,10 @@
 # define NT_FDO_PACKAGING_METADATA 0x407c0c0a
 #endif
 
+#ifndef ELF_NOTE_FDO
+# define ELF_NOTE_FDO "FDO"
+#endif
+
 extern int verbose;
 
 static bool is_dynamic_elf_file(const char *filename, int fd) __attribute__((__nonnull__ (1)));

--- a/utils/initrd-put/enqueue-library.c
+++ b/utils/initrd-put/enqueue-library.c
@@ -18,7 +18,9 @@
 #include "enqueue.h"
 #include "elf_dlopen.h"
 
-#define _FDO_ELF_METADATA 0x407c0c0a
+#ifndef NT_FDO_PACKAGING_METADATA
+# define NT_FDO_PACKAGING_METADATA 0x407c0c0a
+#endif
 
 extern int verbose;
 
@@ -117,7 +119,9 @@ int enqueue_elf_dlopen(const char *filename, int fd)
 
 		off = 0;
 		while ((next = gelf_getnote(data, off, &nhdr, &n_off, &d_off)) > 0) {
-			if (nhdr.n_type == _FDO_ELF_METADATA && nhdr.n_namesz == sizeof(ELF_NOTE_FDO) && !strcmp(data->d_buf + n_off, ELF_NOTE_FDO)) {
+			if (nhdr.n_type == NT_FDO_PACKAGING_METADATA &&
+			    nhdr.n_namesz == sizeof(ELF_NOTE_FDO) &&
+			    !strcmp(data->d_buf + n_off, ELF_NOTE_FDO)) {
 				library[0] = '\0';
 
 				process_json_metadata(filename, (char *)data->d_buf + d_off, library);

--- a/utils/initrd-put/enqueue-shebang.c
+++ b/utils/initrd-put/enqueue-shebang.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #define _GNU_SOURCE
 
+#include "config.h"
+
 #include <stdlib.h>
 #include <stdbool.h>
 #include <ctype.h>

--- a/utils/initrd-put/initrd-put.c
+++ b/utils/initrd-put/initrd-put.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #define _GNU_SOURCE
 
+#include "config.h"
+
 #include <sys/param.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -22,7 +24,6 @@
 #include <regex.h>
 #include <string.h>
 
-#include "config.h"
 #include "memory.h"
 #include "queue.h"
 #include "tree.h"

--- a/utils/initrd-put/initrd-put.c
+++ b/utils/initrd-put/initrd-put.c
@@ -24,6 +24,7 @@
 #include <regex.h>
 #include <string.h>
 
+#include "temp_failure_retry.h"
 #include "memory.h"
 #include "queue.h"
 #include "tree.h"

--- a/utils/initrd-put/memory.c
+++ b/utils/initrd-put/memory.c
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "config.h"
+
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>

--- a/utils/initrd-put/queue.c
+++ b/utils/initrd-put/queue.c
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "config.h"
+
 #include <unistd.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/utils/initrd-put/tree.c
+++ b/utils/initrd-put/tree.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #define _GNU_SOURCE
 
+#include "config.h"
+
 #include <unistd.h>
 #include <stdint.h>
 #include <string.h>
@@ -8,7 +10,6 @@
 #include <sysexits.h>
 #include <err.h>
 
-#include "config.h"
 #include "queue.h"
 #include "tree.h"
 

--- a/utils/initrd-scanmod/Makefile.mk
+++ b/utils/initrd-scanmod/Makefile.mk
@@ -11,7 +11,7 @@ initrd_scanmod_SRCS = \
 	$(utils_srcdir)/initrd-scanmod/initrd-scanmod-walk.c \
 	$(NULL)
 
-initrd_scanmod_LIBS = $(HAVE_LIBKMOD_LIBS)
+initrd_scanmod_LIBS = $(fts_LIBS) $(HAVE_LIBKMOD_LIBS)
 
 PROGS += initrd_scanmod
 endif

--- a/utils/initrd-scanmod/initrd-scanmod-common.c
+++ b/utils/initrd-scanmod/initrd-scanmod-common.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #define _GNU_SOURCE
 
+#include "config.h"
+
 #include <sys/types.h>
 #include <sys/param.h>
 

--- a/utils/initrd-scanmod/initrd-scanmod-file.c
+++ b/utils/initrd-scanmod/initrd-scanmod-file.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "config.h"
+
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/mman.h>

--- a/utils/initrd-scanmod/initrd-scanmod-rules.c
+++ b/utils/initrd-scanmod/initrd-scanmod-rules.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "config.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/utils/initrd-scanmod/initrd-scanmod-walk.c
+++ b/utils/initrd-scanmod/initrd-scanmod-walk.c
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #define _GNU_SOURCE
+
+#include "config.h"
+
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/param.h>

--- a/utils/initrd-scanmod/initrd-scanmod.c
+++ b/utils/initrd-scanmod/initrd-scanmod.c
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #define _GNU_SOURCE
+
+#include "config.h"
+
 #include <sys/utsname.h>
 
 #include <stdio.h>
@@ -12,7 +15,6 @@
 #include <libgen.h>
 
 #include "initrd-scanmod.h"
-#include "config.h"
 
 int verbose = 0;
 

--- a/utils/udev-rules/list_sort.c
+++ b/utils/udev-rules/list_sort.c
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
+#include "config.h"
 #include "list.h"
 
 /*

--- a/utils/udev-rules/udev-goto-label.c
+++ b/utils/udev-rules/udev-goto-label.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "config.h"
+
 #include <stdlib.h>
 #include <stdbool.h>
 #include <err.h>

--- a/utils/udev-rules/udev-rules-parser.y
+++ b/utils/udev-rules/udev-rules-parser.y
@@ -1,4 +1,6 @@
 %{
+#include "config.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>

--- a/utils/udev-rules/udev-rules-scanner.l
+++ b/utils/udev-rules/udev-rules-scanner.l
@@ -1,4 +1,6 @@
 %{
+#include "config.h"
+
 #include <string.h>
 #include <err.h>
 

--- a/utils/udev-rules/udev-rules.c
+++ b/utils/udev-rules/udev-rules.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "config.h"
+
 #include <sys/stat.h>
 
 #include <stdlib.h>

--- a/utils/udev-rules/udev-string.c
+++ b/utils/udev-rules/udev-string.c
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "config.h"
+
 #include <err.h>
 
 #include "udev-string.h"


### PR DESCRIPTION
These patches help build make-initrd on musl-based systems (tested on Gentoo). However, support is not yet complete because musl's `ldconfig` does not support the `-p` argument:
```
$ ldconfig -p
Unimplemented option: -p
```
As a result, all code that relies on `ldconfig -p` (and likely `ldconfig -vNX` too) is currently broken.

This PR contains the first commit from the https://github.com/osboot/make-initrd/pull/46 as both patchsets modify the same areas of the code, even though they are not directly related.